### PR TITLE
Correct what's new to show v2.2.1

### DIFF
--- a/source/whatsnew.rst
+++ b/source/whatsnew.rst
@@ -1,8 +1,8 @@
 What's New
 ##########
 
-Latest (v2.3)
-*************
+Latest (v2.2.1)
+***************
 
 * Expose :ref:`peer verify mode<ssl-socket-peer-verify-mode>` in ``net.SslSocket``.
 


### PR DESCRIPTION
Previous what's new showed version 2.3 as the latest, but we've decided the recent changes can be under version 2.2.1.